### PR TITLE
Support higher ploidy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EvoDynamics"
 uuid = "c8768967-421d-4a02-8523-37736f3dbe06"
 authors = ["Ali R. Vahdati <arv.kavir@gmail.com>", "Carlos Melian"]
-version = "0.0.1"
+version = "0.1.0"
 
 [deps]
 Agents = "46ada45e-f475-11e8-01d0-f70cc89e6671"

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -7,7 +7,7 @@ Random.seed!(10)
 
 P = (4, 5)  # a tuple  specifying the number of traits p for each species
 L = (7, 8)  # a tuple  specifying the number of loci l for each species
-m = 2  # ploidy, m=2 diploid. Currently only haploids are implemented
+m = 1  # ploidy, m=2 diploid. Currently only haploids are implemented
 parameters = Dict(
   :L => L .* m,
   :P => P,

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -7,11 +7,11 @@ Random.seed!(10)
 
 P = (4, 5)  # a tuple  specifying the number of traits p for each species
 L = (7, 8)  # a tuple  specifying the number of loci l for each species
-m = 1  # ploidy, m=2 diploid. Currently only haploids are implemented
+m = 2  # ploidy, m=2 diploid. Currently only haploids are implemented
 parameters = Dict(
-  :L => L,
+  :L => L .* m,
   :P => P,
-  :B =>  Tuple([Random.bitrand(i[1], i[2]) for i in zip(P, L)]),  # a tuple  of pleiotropy matrices, one for each species. Each matrix consists of zeros and ones only. make sure no rows are all zero (a trait is not controled :by any locus)
+  :B =>  Tuple([Random.bitrand(i[1], i[2]) for i in zip(P, L .* m)]),  # a tuple  of pleiotropy matrices, one for each species. Each matrix consists of zeros and ones only. make sure no rows are all zero (a trait is not controled :by any locus)
   :γ => (-0.5, -0.5), # a tuple  of selection coefficients for each species
   :m => m,
   :T => Tuple([randn(Float16, n) for n in P]), # a tuple  of arrays, each inner array θ specifying optimal phenotypes for each species
@@ -19,7 +19,7 @@ parameters = Dict(
   :M => (0.02, 0.02), # a tuple of mutation rates μ for each species
   :MB => (0.05, 0.05), # a tuple of mutation rates μ<sub>B</sub> for each species
   :N => (1000, 1000), # a tuple  for population size of each species
-  :Y => Tuple([rand(Float16, i*m) for i in L]), # a tuple  of Arrays, each specifying the initial y vector of each species
+  :Y => Tuple([rand(Float16, i) for i in L .* m]), # a tuple  of Arrays, each specifying the initial y vector of each species
   :E => (0.8, 0.8), # a tuple  of the variance of a normal distribution ε representing environmental noise for each species.
   :generations => 100 # number of generations to run the simulation
 )

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -37,6 +37,8 @@ function model_initiation(;L, P, B, γ, m, T, Ω, M, MB, N, Y, E, generations, s
     Random.seed!(seed)
   end
 
+  @assert length.(Y) .% m == Tuple([0 for i in 1:length(Y)])
+
   Ed = [Normal(0.0, i) for i in E]
 
   # A descrete non-parametric distribtion of uB for each species


### PR DESCRIPTION
Answers #1 

It turns out that the model already support diploids or mutiploids through additive effects. Vector `y` and matrix `B` will become larger depending on ploidy.